### PR TITLE
id:3122 Add recent numbers cache to avoid automated text message war

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,27 @@
+class Cache {
+    constructor() {
+        this._cache = {};
+    }
+
+    async buildCompositeKey(key1, key2) {
+        return `${key1}-${key2}`;
+    }
+
+    async saveValueByKey(key, value) {
+        this._cache[key] = value;
+    }
+
+    async getValueByKey(key) {
+        return this._cache[key] || null;
+    }
+
+    async deleteKey(key) {
+        delete this._cache[key];
+    }
+
+    async getNumberOfItemsInCache() {
+        return Object.keys(this._cache).length;
+    }
+}
+
+module.exports = Cache;

--- a/cache.js
+++ b/cache.js
@@ -1,6 +1,11 @@
+const moment = require('moment');
+
 class Cache {
-    constructor() {
+    constructor(config) {
         this._cache = {};
+        this.config = config;
+
+        setInterval(() => this.cleanKeys(), this.config.automatedResponseTimeLimit);
     }
 
     async buildCompositeKey(key1, key2) {
@@ -21,6 +26,16 @@ class Cache {
 
     async getNumberOfItemsInCache() {
         return Object.keys(this._cache).length;
+    }
+
+    cleanKeys() {
+        const keys = Object.keys(this._cache);
+        keys.forEach(key => {
+            const duration = moment.duration(moment.utc().diff(this._cache[key]));
+            if (duration.asMilliseconds() > this.config.automatedResponseTimeLimit) {
+                this.deleteKey(key);
+            }
+        });
     }
 }
 

--- a/config.js
+++ b/config.js
@@ -37,5 +37,6 @@ module.exports = {
     phoneNumberFormat: process.env.SMS_PHONE_NUMBER_FORMAT || '(NNN) NNN-NNNN', // used for formatting originating numbers in email notifications
     mediaStoragePath: process.env.SMS_MEDIA_STORAGE_PATH || '/tmp',
     localTimezone: process.env.SMS_LOCAL_TIMEZONE || 'America/New_York',
-    imageFormats: process.env.SMS_IMAGE_FORMATS || ['gif', 'bmp', 'jpg', 'png', 'tiff']
+    imageFormats: process.env.SMS_IMAGE_FORMATS || ['gif', 'bmp', 'jpg', 'png', 'tiff'],
+    automatedResponseTimeLimit: process.env.SMS_AUTOMATED_RESPONSE_TIME_LIMIT || 15000
 };

--- a/config.js
+++ b/config.js
@@ -38,5 +38,5 @@ module.exports = {
     mediaStoragePath: process.env.SMS_MEDIA_STORAGE_PATH || '/tmp',
     localTimezone: process.env.SMS_LOCAL_TIMEZONE || 'America/New_York',
     imageFormats: process.env.SMS_IMAGE_FORMATS || ['gif', 'bmp', 'jpg', 'png', 'tiff'],
-    automatedResponseTimeLimit: process.env.SMS_AUTOMATED_RESPONSE_TIME_LIMIT || 15000
+    automatedResponseTimeLimit: process.env.SMS_AUTOMATED_RESPONSE_TIME_LIMIT || 1000 * 60 * 15 // 15 minutes
 };

--- a/index.js
+++ b/index.js
@@ -2,12 +2,16 @@ const path = require('path');
 const ReperioServer = require('hapijs-starter');
 
 const API = require('./api');
+const Cache = require('./cache');
 const config = require('./config');
 const LoggingHelper = require('./helpers/loggingHelper');
 const MessageHelper = require('./helpers/messageHelper');
 
 const start = async () => {
     try {
+        // initialize the cache
+        const recentNumbersCache = new Cache();
+
         //status monitor is turned off due to dependency issue with the pidusage dependency on the master branch of hapijs-status-monitor
         const reperio_server = new ReperioServer({
             statusMonitor: false,
@@ -58,7 +62,7 @@ const start = async () => {
             type: 'onRequest',
             method: async (request, h) => {
                 request.app.getNewMessageHelper = async () => {
-                    return new MessageHelper(request.app.logger, reperio_server.app.config);
+                    return new MessageHelper(request.app.logger, reperio_server.app.config, recentNumbersCache);
                 };
                 
                 return h.continue;

--- a/tests/unit/cache.unit.spec.js
+++ b/tests/unit/cache.unit.spec.js
@@ -1,0 +1,40 @@
+/* eslint-env  jest */
+
+const Cache = require('../../cache');
+
+describe('Cache unit tests', function () {
+    let cache = null;
+    
+    beforeEach(() => {
+        cache = new Cache();
+    });
+
+    it('can build composite key', async () => {
+        expect(await cache.buildCompositeKey('test1', 'test2')).toEqual('test1-test2');
+    });
+
+    it('should have 0 items in new cache', async () => {
+        expect(await cache.getNumberOfItemsInCache()).toEqual(0);
+    });
+
+    it('can add value to cache by key', async () => {
+        await cache.saveValueByKey('key', 'value');
+        expect(await cache.getNumberOfItemsInCache()).toEqual(1);
+    });
+
+    it('can fetch value from cache by key', async () => {
+        cache._cache.key = 'value';
+        expect(await cache.getValueByKey('key')).toEqual('value');
+    });
+
+    it('returns null if key does not exist in cache', async () => {
+        expect(await cache.getValueByKey('key')).toBeNull();
+    });
+
+    it('can delete value from cache', async () => {
+        cache._cache.key = 'value';
+        expect(await cache.getNumberOfItemsInCache()).toEqual(1);
+        await cache.deleteKey('key');
+        expect(await cache.getNumberOfItemsInCache()).toEqual(0);
+    });
+});


### PR DESCRIPTION
Default response timeout is 15 minutes. Prevents replies from one incoming number to one destination number.

So if I send a message to phone 1, get the automated response, and reply to that response, I will not get another message. But if I then send a message to phone 2, I'll still get the automated response (but no further automated responses for 15 minutes).